### PR TITLE
Add parentheses, remove unused variables, replace abs by fabs

### DIFF
--- a/src/dqagi.c
+++ b/src/dqagi.c
@@ -81,7 +81,7 @@ double dqagi(dq_function_type f,double bound,int inf,double epsabs,
     if ((*abserr <= 100.0 * epmach * defabs) && (*abserr > errbnd))
         *ier = 2;
     if (limit == 0) *ier = 1;
-    if ((*ier != 0) || (*abserr <= errbnd) && (*abserr != resabs) ||
+    if ((*ier != 0) || ((*abserr <= errbnd) && (*abserr != resabs)) ||
         (*abserr == 0.0)) goto _130;
 
 /* Initialization for main loop. */

--- a/src/dqags.c
+++ b/src/dqags.c
@@ -68,7 +68,7 @@ double dqags(dq_function_type f,double a,double b,double epsabs,
     if ((*abserr <= 100.0 * epmach * defabs) && (*abserr > errbnd))
         *ier = 2;
     if (limit == 0) *ier = 1;
-    if ((*ier != 0) || (*abserr <= errbnd) && (*abserr != resabs) ||
+    if ((*ier != 0) || ((*abserr <= errbnd) && (*abserr != resabs)) ||
         (*abserr == 0.0)) goto _140;
 
 /* Initialization. */

--- a/src/dqk15i.c
+++ b/src/dqk15i.c
@@ -42,7 +42,7 @@ double G_K15I(dq_function_type f, double boun, int inf, double a, double b,
     fc=(fval1/centr)/centr;
     resg = fc * WG7[3];
     resk = fc * WGK15[7];
-    *resabs = abs(resk);
+    *resabs = fabs(resk);
     for (j = 0; j < 7; j++) {
         absc = hlgth * XGK15[j];
         absc1 = centr - absc;
@@ -62,17 +62,17 @@ double G_K15I(dq_function_type f, double boun, int inf, double a, double b,
         fsum = fval1 + fval2;
         if (j & 1) resg += WG7[j/2] * fsum; /* odd 'j's are truncated */
         resk += WGK15[j] * fsum;
-        *resabs = (*resabs) + WGK15[j] * (abs(fval1) + abs(fval2));
+        *resabs = (*resabs) + WGK15[j] * (fabs(fval1) + fabs(fval2));
     }
     reskh = resk * 0.5;
-    *resasc = WGK15[7] * abs(fc - reskh);
+    *resasc = WGK15[7] * fabs(fc - reskh);
     for (j = 0; j < 7; j++ )
-        *resasc = (*resasc) + WGK15[j] * (abs(fv1[j] - reskh) +
-            abs(fv2[j] - reskh));
+        *resasc = (*resasc) + WGK15[j] * (fabs(fv1[j] - reskh) +
+            fabs(fv2[j] - reskh));
     result = resk * hlgth;
     *resabs = (*resabs) * hlgth;
     *resasc = (*resasc) * hlgth;
-    *abserr = abs((resk - resg) * hlgth);
+    *abserr = fabs((resk - resg) * hlgth);
     if ((*resasc != 0.0) && (*abserr != 0.0))
         *abserr = (*resasc) * min(1.0,pow((200.0 * (*abserr)/(*resasc)),1.5));
     if (*resabs > uflow/(50.0 * epmach))

--- a/src/dqk15i.c
+++ b/src/dqk15i.c
@@ -27,7 +27,7 @@ double G_K15I(dq_function_type f, double boun, int inf, double a, double b,
         0.38183005050511894495,
         0.41795918367346938776};
     double fv1[8],fv2[8];
-    double absc,absc1,absc2,centr,dinf,dmax1,dmin1;
+    double absc,absc1,absc2,centr,dinf;
     double fc,fsum,fval1,fval2,hlgth,resg,resk;
     double reskh,result,tabsc1,tabsc2;
     int j;


### PR DESCRIPTION
This PR includes three changes:

1) Add parenthesis around && operator: This improved the readability of the code and prevents a compiler warning with gcc.
2) Remove unused variables.
3) Use fabs instead of abs in dqagi.c: This might have been even a bug. The abs function computes the absolute value of an integer. So, here the double will be converted to an integer and the absolute value of the integer will be computed. I think the right behavior is to compute the absolute value of the double.