### PR TITLE
Initialize variable small

### DIFF
--- a/src/dqagi.c
+++ b/src/dqagi.c
@@ -43,7 +43,7 @@ double dqagi(dq_function_type f,double bound,int inf,double epsabs,
     double erlast,errbnd,errmax,error1,error2,erro12;
     double errsum,ertest,resabs,reseps,result,res3la[3];
     double alist[LIMIT],blist[LIMIT],elist[LIMIT],rlist[LIMIT];
-    double rlist2[52],small;
+    double rlist2[52],small = 0; /* small will be initialized in _80 */
 
     int id,ierro,iord[LIMIT],iroff1,iroff2,iroff3,jupbnd,k,ksgn;
     int ktmin,last,maxerr,nres,nrmax,numrl2;

--- a/src/dqags.c
+++ b/src/dqags.c
@@ -34,7 +34,7 @@ double dqags(dq_function_type f,double a,double b,double epsabs,
     double defab2,dres,elist[LIMIT],erlarg,erlast,errbnd;
     double errmax,error1,error2,erro12,errsum,ertest;
     double resabs,reseps,result,res3la[3],rlist[LIMIT];
-    double rlist2[52],small;
+    double rlist2[52],small = 0; /* small will be initialized in _80 */
 
     int id,ierro,iord[LIMIT],iroff1,iroff2,iroff3,jupbnd,k,ksgn;
     int ktmin,last,maxerr,nres,nrmax,numrl2;


### PR DESCRIPTION
gcc complains that the variable small may be used initialized. Actually, small will be initialized at the first iteration of the loop for last == 1 (see label _80). To prevent gcc from printing the warning, initialize small to 0.