### PR TITLE
Fix wrong index when writing to array

### DIFF
--- a/src/dqagi.c
+++ b/src/dqagi.c
@@ -235,7 +235,7 @@ _80:
         small = .375;
         erlarg = errsum;
         ertest = errbnd;
-        rlist2[0] = area;
+        rlist2[1] = area;
 _90:
         ;
     }                    /* 90: */


### PR DESCRIPTION
This commit fixes a bug: At one point the index when writing to the array rlist
was wrong. The original QUADPACK code looks like:

    80   small = 0.375d+00
         erlarg = errsum
         ertest = errbnd
         rlist2(2) = area
    90 continue

As arrays start with index 0 in C, the access of rlist2 should look like:

    rlist[1] = area;

This change also fixes undeterministic behavior of the function dquadi due to a
use of uninitialized value. With this fix the memory access seems fine and
LLVM's MemorySanitizer does no longer complain.