### PR TITLE
Fix access on uninitialized memory

### DIFF
--- a/src/dqfour.c
+++ b/src/dqfour.c
@@ -101,11 +101,11 @@ _5:
     ktmin = 0;
     small = fabs(b-a) * 0.75;
     nres = 0;
-    numrl2 = 0;
+    numrl2 = -1;
     extall = FALSE;
     if ((0.5 * fabs(b-a) * domega) > 2.0)
         goto _10;
-    numrl2 = 1;
+    numrl2 = 0;
     extall = TRUE;
     rlist2[0] = result;
 _10:


### PR DESCRIPTION
The original Fortran code looks like (see
http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=quadpack%2Fdqawo.f)

    numrl2 = 0
    extall = .false.
    if(0.5d+00*dabs(b-a)*domega.gt.0.2d+01) go to 10
    numrl2 = 1

For this reason the C code should look like
    numrl2 = -1;
    ...
    numrl2 = 0;

After this patch LLVM no longer complains about uninitialized access on memory.