### PR TITLE
Fix some minor problems

### DIFF
--- a/include/cquadpack.h
+++ b/include/cquadpack.h
@@ -12,7 +12,7 @@
 #ifdef M_PI
 #define Pi      M_PI
 #else
-#define Pi      3.114159265358979323846
+#define Pi      3.14159265358979323846
 #endif
 #define COSINE     1
 #define SINE    2

--- a/include/cquadpack.h
+++ b/include/cquadpack.h
@@ -9,7 +9,7 @@
 #define epmach     DBL_EPSILON
 #define LIMIT     500
 #define MAXP1     21
-#define Pi      M_PI
+#define Pi      3.141592653589793
 #define COSINE     1
 #define SINE    2
 

--- a/include/cquadpack.h
+++ b/include/cquadpack.h
@@ -9,7 +9,11 @@
 #define epmach     DBL_EPSILON
 #define LIMIT     500
 #define MAXP1     21
-#define Pi      3.141592653589793
+#ifdef M_PI
+#define Pi      M_PI
+#else
+#define Pi      3.114159265358979323846
+#endif
 #define COSINE     1
 #define SINE    2
 

--- a/src/dqawf.c
+++ b/src/dqawf.c
@@ -2,6 +2,7 @@
 
 #include <malloc.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define P   0.9
 

--- a/src/dqawo.c
+++ b/src/dqawo.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <malloc.h>
+#include <stdlib.h>
 
 double dqawo(dq_function_type f,double a,double b,double omega, int sincos,
     double epsabs,double epsrel,double *abserr,int *neval,

--- a/src/dqawo.c
+++ b/src/dqawo.c
@@ -8,7 +8,7 @@ double dqawo(dq_function_type f,double a,double b,double omega, int sincos,
     double epsabs,double epsrel,double *abserr,int *neval,
     int *ier, void* user_data)
 {
-    double **chebmo,res3a[52],result,rlist2[52];
+    double **chebmo,result;
     int i,momcom;
 
     if ((chebmo = (double **)calloc(MAXP1,sizeof(double *))) == NULL) {

--- a/src/dqc25o.c
+++ b/src/dqc25o.c
@@ -21,7 +21,7 @@ double dqc25o(dq_function_type f,double a,double b,double omega,int sincos,
     double ac,an,an2,as,asap,ass,centr,conc,cons,cospar;
     double estc,ests,hlgth,parint,par2,par22;
     double resc12,resc24,ress12,ress24,result,sinpar;
-    double cheb12[13],cheb24[25],c[28],d[28],d1[28],d2[28];
+    double cheb12[13],cheb24[25],d[28],d1[28],d2[28];
     double d3[28],fval[25],v[28];
     int unitialized_value = 0xCCCCCCCC;
     double p2 = unitialized_value, p3 = unitialized_value, p4 = unitialized_value;

--- a/src/dqk15.c
+++ b/src/dqk15.c
@@ -27,7 +27,7 @@ double G_K15(dq_function_type f,double a,double b,double *abserr,
         0.38183005050511894495,
         0.41795918367346938776};
     double fv1[7],fv2[7];
-    double absc,centr,dhlgth,dmax1,dmin1;
+    double absc,centr,dhlgth;
     double fc,fsum,fval1,fval2,hlgth;
     double resg,resk,reskh,result;
     int j,jtw,jtwm1;

--- a/src/dqk15w.c
+++ b/src/dqk15w.c
@@ -28,7 +28,7 @@ double G_K15W(dq_function_type f,double w(),double p1,double p2,double p3,
         0.38183005050511894495,
         0.41795918367346938776};
     double fv1[7],fv2[7];
-    double absc,absc1,absc2,centr,dhlgth,dmax1,dmin1;
+    double absc,absc1,absc2,centr,dhlgth;
     double fc,fsum,fval1,fval2,hlgth;
     double resg,resk,reskh,result;
     int j,jtw,jtwm1;

--- a/src/dqk31.c
+++ b/src/dqk31.c
@@ -48,7 +48,7 @@ double G_K31(dq_function_type f,double a,double b,double *abserr,
         0.20257824192556127288};
 
     double fv1[15],fv2[15];
-    double absc,centr,dhlgth,dmax1,dmin1;
+    double absc,centr,dhlgth;
     double fc,fsum,fval1,fval2,hlgth;
     double resg,resk,reskh,result;
     int j,jtw,jtwm1;

--- a/src/dqk41.c
+++ b/src/dqk41.c
@@ -62,7 +62,7 @@ double G_K41(dq_function_type f,double a,double b,double *abserr,
         0.14917298647260374679,
         0.15275338713072585070};
     double fv1[20],fv2[20];
-    double absc,centr,dhlgth,dmax1,dmin1;
+    double absc,centr,dhlgth;
     double fc,fsum,fval1,fval2,hlgth;
     double resg,resk,reskh,result;
     int j,jtw,jtwm1;

--- a/src/dqk51.c
+++ b/src/dqk51.c
@@ -76,7 +76,7 @@ double G_K51(dq_function_type f,double a,double b,double *abserr,
         0.12317605372671545120};
 
     double fv1[25],fv2[25];
-    double absc,centr,dhlgth,dmax1,dmin1;
+    double absc,centr,dhlgth;
     double fc,fsum,fval1,fval2,hlgth;
     double resg,resk,reskh,result;
     int j,jtw,jtwm1;

--- a/src/dqk61.c
+++ b/src/dqk61.c
@@ -89,7 +89,7 @@ double G_K61(dq_function_type f,double a,double b,double *abserr,
         0.10285265289355884034};
 
     double fv1[30],fv2[30];
-    double absc,centr,dhlgth,dmax1,dmin1;
+    double absc,centr,dhlgth;
     double fc,fsum,fval1,fval2,hlgth;
     double resg,resk,reskh,result;
     int j,jtw,jtwm1;

--- a/src/dqng.c
+++ b/src/dqng.c
@@ -142,8 +142,8 @@ double dqng(dq_function_type f,double a,double b,double epsabs,
         0.03733422875193504032,
         0.03736107376267902341};
     double fv1[5],fv2[5],fv3[5],fv4[5],savfun[21];
-    double absc,centr,dhlgth,dmax1,dmin1;
-    double fcentr,fsum,fval,fval1,fval2,hlgth;
+    double absc,centr,dhlgth;
+    double fcentr,fval,fval1,fval2,hlgth;
     double result,res10,res21,res43,res87;
     double resabs,resasc,reskh;
     int ipx,k,l;


### PR DESCRIPTION
This PR fixes some minor issues:

- Remove some unused variables.
- Include header file stdlib.h in files that use the exit-function.
- Define the macro Pi explicitly.

The first two points are pretty straight-forward: Those changes prevent warning when compiling the code.

The last point is more subtile: The macro M_PI is not defined in standard C, so compiling fails for example if you use gcc with the flag -std=c99.