### PR TITLE
Fix use of wrong variable

### DIFF
--- a/src/dqags.c
+++ b/src/dqags.c
@@ -127,7 +127,7 @@ _15:
         if (((iroff1 + iroff2) >= 10) || (iroff3 >= 20))
             *ier = 2;
         if (iroff2 > 5)
-            *ier = 3;
+            ierro = 3;
 
 /* Set error flag in the case that the number of subintervals
     equals limit. */


### PR DESCRIPTION
In the case of roundoff errors the *ier was set to 3. This, however, is wrong.
As can be seen from the original Fortran file [1], the variable ierro should be
set to 3.

[1] http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=quadpack%2Fdqags.f