### PR TITLE
remove asignments

### DIFF
--- a/src/dqagi.c
+++ b/src/dqagi.c
@@ -72,7 +72,6 @@ double dqagi(dq_function_type f,double bound,int inf,double epsabs,
     result = G_K15I(f,boun,inf,0.0,1.0,abserr,&defabs,&resabs, user_data);
 
 /* Test on accuracy. */
-    last = 0;
     rlist[0] = result;
     elist[0] = *abserr;
     iord[0] = 0;

--- a/src/dqags.c
+++ b/src/dqags.c
@@ -55,7 +55,6 @@ double dqags(dq_function_type f,double a,double b,double epsabs,
     if (*ier == 6) return result;
 
 /* First approximation to the integral. */
-    ierro = 0;
     result = G_K21(f,a,b,abserr,&defabs,&resabs, user_data);
 
 /* Test on accuracy. */


### PR DESCRIPTION
Remove assignments, because they are dead code. In both cases there are no
jumps or goto-labels between the two assignments, so one assignment is
redundant.